### PR TITLE
Switch to kinesis_predictions()

### DIFF
--- a/mind-bot-race/neurosity-crown/crown_test.py
+++ b/mind-bot-race/neurosity-crown/crown_test.py
@@ -22,5 +22,5 @@ def callback(data):
     print("Right Arm:", data.probability)
 
 # unsubscribe = neurosity.brainwaves_raw(callback)
-unsubscribe = neurosity.kinesis("rightArm", callback)
+unsubscribe = neurosity.kinesis_predictions("rightArm", callback)
 

--- a/mind-bot-race/neurosity-crown/micromelon_test.py
+++ b/mind-bot-race/neurosity-crown/micromelon_test.py
@@ -2,7 +2,7 @@ from micromelon import *
 
 rc = RoverController()
 
-rc.connectBLE(83)
+rc.connectBLE(145)
 rc.startRover()
 
 while True:

--- a/mind-bot-race/neurosity-crown/mindcontrol-v1.py
+++ b/mind-bot-race/neurosity-crown/mindcontrol-v1.py
@@ -37,7 +37,7 @@ def main():
     # kinesis_type = "blah blah" # ect. ect. (there are allot of them)
 
     # Assign the chosen kenisis metric to our callback function
-    unsubscribe = neurosity.kinesis(kinesis_type, callback)
+    unsubscribe = neurosity.kinesis_predictions(kinesis_type, callback)
 
     # If you uncomment any of these, it will break the code:
 

--- a/mind-bot-race/neurosity-crown/mindcontrol-v2.py
+++ b/mind-bot-race/neurosity-crown/mindcontrol-v2.py
@@ -40,8 +40,8 @@ def main():
     # kinesis_type_2 = "blah blah" # ect. ect. (there are allot of them)
 
     # Assign the chosen kenisis metrics to our callback function
-    unsubscribe = neurosity.kinesis(kinesis_type_1, callback)
-    unsubscribe2 = neurosity.kinesis(kinesis_type_2, callback)
+    unsubscribe = neurosity.kinesis_predictions(kinesis_type_1, callback)
+    unsubscribe2 = neurosity.kinesis_predictions(kinesis_type_2, callback)
 
     # If you uncomment any of these, it will break the code:
 

--- a/mind-bot-race/neurosity-crown/other-code/motors_running.py
+++ b/mind-bot-race/neurosity-crown/other-code/motors_running.py
@@ -37,8 +37,8 @@ def main():
     roverInit()
 
     # unsubscribe = neurosity.brainwaves_raw(callback)
-    unsubscribe = neurosity.kinesis("rightArm", callback)
-    unsubscribe2 = neurosity.kinesis("leftArm", callback2)
+    unsubscribe = neurosity.kinesis_predictions("rightArm", callback)
+    unsubscribe2 = neurosity.kinesis_predictions("leftArm", callback2)
     
     # unsubscribe = neurosity.focus(callback)
 


### PR DESCRIPTION
In our testing, kinesis() was unreliable and kinesis_predictions() seemed to offer a more consistent stream of data to work with, while offering a "prediction" value. Hence this PR aims to replace the examples and code with kinesis_predictions()